### PR TITLE
Add Flask session API and client login

### DIFF
--- a/docs/login.html
+++ b/docs/login.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form id="loginForm" class="card" style="max-width:300px;margin:2rem auto;">
+    <h2>Login</h2>
+    <label class="small">Username<input name="username" type="text" required /></label>
+    <label class="small">Password<input name="password" type="password" required /></label>
+    <button type="submit">Login</button>
+    <div id="msg" class="small" style="color:red;"></div>
+  </form>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const form = e.target;
+      const res = await fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ username: form.username.value, password: form.password.value })
+      });
+      if (res.ok) {
+        window.location.href = 'index.html';
+      } else {
+        document.getElementById('msg').textContent = 'Invalid credentials';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -51,6 +51,24 @@
                               return a[idx];
                     }
 
+                    async function checkSession() {
+                              try {
+                                        const res = await fetch('/api/session', { credentials: 'include' });
+                                        const data = res.ok ? await res.json() : { role: 'guest' };
+                                        if (data.role !== 'admin') {
+                                                  ['downloadLatest', 'exportBar', 'exportLine'].forEach(id => {
+                                                            const el = document.getElementById(id);
+                                                            if (el) { el.disabled = true; el.style.display = 'none'; }
+                                                  });
+                                        }
+                              } catch (e) {
+                                        ['downloadLatest', 'exportBar', 'exportLine'].forEach(id => {
+                                                  const el = document.getElementById(id);
+                                                  if (el) { el.disabled = true; el.style.display = 'none'; }
+                                        });
+                              }
+                    }
+
                     // Robust fetch with timeout + retry
                     async function fetchWithRetry(url, { timeout = 8000, retries = 2 } = {}) {
                               for (let attempt = 0; attempt <= retries; attempt++) {
@@ -276,6 +294,7 @@
                     (async function init() {
                               try {
                                         loadPrefs();
+                                        await checkSession();
                                         document.getElementById('messages').textContent = 'Loading data…';
                                         const rows = await loadCSV();
                                         state.rows = rows;

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,79 @@
+import os
+import sqlite3
+from flask import Flask, request, session, jsonify, g
+from werkzeug.security import check_password_hash, generate_password_hash
+
+app = Flask(__name__, static_folder='../docs', static_url_path='')
+app.secret_key = os.environ.get('SECRET_KEY', 'dev-secret')
+
+DATABASE = os.path.join(os.path.dirname(__file__), 'app.db')
+
+
+def get_db():
+    if 'db' not in g:
+        g.db = sqlite3.connect(DATABASE)
+        g.db.row_factory = sqlite3.Row
+    return g.db
+
+
+@app.teardown_appcontext
+def close_db(exception=None):
+    db = g.pop('db', None)
+    if db is not None:
+        db.close()
+
+
+def init_db():
+    db = get_db()
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password TEXT NOT NULL,
+            role TEXT NOT NULL
+        )
+        """
+    )
+    db.commit()
+
+
+@app.before_request
+def before_request():
+    init_db()
+
+
+@app.route('/login', methods=['POST'])
+def login():
+    data = request.get_json() or request.form
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({'error': 'Missing credentials'}), 400
+    db = get_db()
+    cur = db.execute('SELECT username, password, role FROM users WHERE username = ?', (username,))
+    row = cur.fetchone()
+    if row and check_password_hash(row['password'], password):
+        session['user'] = row['username']
+        session['role'] = row['role']
+        return jsonify({'ok': True})
+    return jsonify({'ok': False}), 401
+
+
+@app.route('/logout', methods=['POST'])
+def logout():
+    session.clear()
+    return jsonify({'ok': True})
+
+
+@app.route('/api/session')
+def api_session():
+    user = session.get('user')
+    role = session.get('role', 'guest')
+    if not user:
+        role = 'guest'
+    return jsonify({'user': user, 'role': role})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- Implement Flask server with SQLite-backed users table, login/logout routes, and `/api/session` endpoint.
- Add login page posting credentials to the server and redirecting on success.
- Fetch session info on dashboard load and hide admin-only actions for non-admin users.

## Testing
- `python -m py_compile server/app.py`
- `node --check docs/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bece735f908328b731839ce57ed420